### PR TITLE
Add tiers and chat setting limits

### DIFF
--- a/app/api/chat/azure/route.ts
+++ b/app/api/chat/azure/route.ts
@@ -1,14 +1,15 @@
-import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkApiKey, getServerProfile, trackMessageCount } from "@/lib/server/server-chat-helpers"
 import { ChatAPIPayload } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import OpenAI from "openai"
 import { ChatCompletionCreateParamsBase } from "openai/resources/chat/completions.mjs"
+import { MESSAGE_LIMITS } from "@/lib/tier-limits"
 
 export const runtime = "edge"
 
 export async function POST(request: Request) {
   const json = await request.json()
-  const { chatSettings, messages } = json as ChatAPIPayload
+  const { chatSettings, messages, userTier } = json as ChatAPIPayload & { userTier: string }
 
   try {
     const profile = await getServerProfile()
@@ -41,6 +42,19 @@ export async function POST(request: Request) {
         {
           status: 400
         }
+      )
+    }
+
+    // Check message limits based on user's tier
+    const userMessageLimit = MESSAGE_LIMITS[chatSettings.model][userTier]
+    const userMessageCount = await trackMessageCount(userTier, chatSettings.model)
+
+    if (userMessageCount >= userMessageLimit) {
+      return new Response(
+        JSON.stringify({
+          message: `Message limit reached for today. Upgrade to get more usage.`
+        }),
+        { status: 400 }
       )
     }
 

--- a/app/api/chat/groq/route.ts
+++ b/app/api/chat/groq/route.ts
@@ -1,21 +1,37 @@
 import { CHAT_SETTING_LIMITS } from "@/lib/chat-setting-limits"
-import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkApiKey, getServerProfile, trackMessageCount } from "@/lib/server/server-chat-helpers"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import OpenAI from "openai"
+import { MESSAGE_LIMITS } from "@/lib/tier-limits"
 
 export const runtime = "edge"
+
 export async function POST(request: Request) {
   const json = await request.json()
-  const { chatSettings, messages } = json as {
+  const { chatSettings, messages, userTier } = json as {
     chatSettings: ChatSettings
     messages: any[]
+    userTier: string
   }
 
   try {
     const profile = await getServerProfile()
 
-    checkApiKey(profile.groq_api_key, "G")
+    checkApiKey(profile.groq_api_key, "Groq")
+
+    // Check message limits based on user's tier
+    const userMessageLimit = MESSAGE_LIMITS[chatSettings.model][userTier]
+    const userMessageCount = await trackMessageCount(userTier, chatSettings.model)
+
+    if (userMessageCount >= userMessageLimit) {
+      return new Response(
+        JSON.stringify({
+          message: `Message limit reached for today. Upgrade to get more usage.`
+        }),
+        { status: 400 }
+      )
+    }
 
     // Groq is compatible with the OpenAI SDK
     const groq = new OpenAI({

--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -1,25 +1,38 @@
-import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkApiKey, getServerProfile, trackMessageCount } from "@/lib/server/server-chat-helpers"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import { ServerRuntime } from "next"
 import OpenAI from "openai"
 import { ChatCompletionCreateParamsBase } from "openai/resources/chat/completions.mjs"
+import { MESSAGE_LIMITS } from "@/lib/tier-limits"
 
 export const runtime: ServerRuntime = "edge"
 
 export async function POST(request: Request) {
   const json = await request.json()
-  const { chatSettings, messages } = json as {
+  const { chatSettings, messages, userTier } = json as {
     chatSettings: ChatSettings
     messages: any[]
+    userTier: string
   }
 
   try {
-
-    
     const profile = await getServerProfile()
 
     checkApiKey(profile.openai_api_key, "OpenAI")
+
+    // Check message limits based on user's tier
+    const userMessageLimit = MESSAGE_LIMITS[chatSettings.model][userTier]
+    const userMessageCount = await trackMessageCount(userTier, chatSettings.model)
+
+    if (userMessageCount >= userMessageLimit) {
+      return new Response(
+        JSON.stringify({
+          message: `Message limit reached for today. Upgrade to get more usage.`
+        }),
+        { status: 400 }
+      )
+    }
 
     const openai = new OpenAI({
       apiKey: profile.openai_api_key || "",

--- a/app/api/chat/openrouter/route.ts
+++ b/app/api/chat/openrouter/route.ts
@@ -1,23 +1,38 @@
-import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkApiKey, getServerProfile, trackMessageCount } from "@/lib/server/server-chat-helpers"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import { ServerRuntime } from "next"
 import OpenAI from "openai"
 import { ChatCompletionCreateParamsBase } from "openai/resources/chat/completions.mjs"
+import { MESSAGE_LIMITS } from "@/lib/tier-limits"
 
 export const runtime: ServerRuntime = "edge"
 
 export async function POST(request: Request) {
   const json = await request.json()
-  const { chatSettings, messages } = json as {
+  const { chatSettings, messages, userTier } = json as {
     chatSettings: ChatSettings
     messages: any[]
+    userTier: string
   }
 
   try {
     const profile = await getServerProfile()
 
     checkApiKey(profile.openrouter_api_key, "OpenRouter")
+
+    // Check message limits based on user's tier
+    const userMessageLimit = MESSAGE_LIMITS[chatSettings.model][userTier]
+    const userMessageCount = await trackMessageCount(userTier, chatSettings.model)
+
+    if (userMessageCount >= userMessageLimit) {
+      return new Response(
+        JSON.stringify({
+          message: `Message limit reached for today. Upgrade to get more usage.`
+        }),
+        { status: 400 }
+      )
+    }
 
     const openai = new OpenAI({
       apiKey: profile.openrouter_api_key || "",

--- a/app/api/chat/perplexity/route.ts
+++ b/app/api/chat/perplexity/route.ts
@@ -1,21 +1,36 @@
-import { checkApiKey, getServerProfile } from "@/lib/server/server-chat-helpers"
+import { checkApiKey, getServerProfile, trackMessageCount } from "@/lib/server/server-chat-helpers"
 import { ChatSettings } from "@/types"
 import { OpenAIStream, StreamingTextResponse } from "ai"
 import OpenAI from "openai"
+import { MESSAGE_LIMITS } from "@/lib/tier-limits"
 
 export const runtime = "edge"
 
 export async function POST(request: Request) {
   const json = await request.json()
-  const { chatSettings, messages } = json as {
+  const { chatSettings, messages, userTier } = json as {
     chatSettings: ChatSettings
     messages: any[]
+    userTier: string
   }
 
   try {
     const profile = await getServerProfile()
 
     checkApiKey(profile.perplexity_api_key, "Perplexity")
+
+    // Check message limits based on user's tier
+    const userMessageLimit = MESSAGE_LIMITS[chatSettings.model][userTier]
+    const userMessageCount = await trackMessageCount(userTier, chatSettings.model)
+
+    if (userMessageCount >= userMessageLimit) {
+      return new Response(
+        JSON.stringify({
+          message: `Message limit reached for today. Upgrade to get more usage.`
+        }),
+        { status: 400 }
+      )
+    }
 
     // Perplexity is compatible the OpenAI SDK
     const perplexity = new OpenAI({

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -20,6 +20,7 @@ import { useChatHandler } from "./chat-hooks/use-chat-handler"
 import { useChatHistoryHandler } from "./chat-hooks/use-chat-history"
 import { usePromptAndCommand } from "./chat-hooks/use-prompt-and-command"
 import { useSelectFileHandler } from "./chat-hooks/use-select-file-handler"
+import { MESSAGE_LIMITS, TIERS } from "@/lib/tier-limits"
 
 interface ChatInputProps {}
 
@@ -54,7 +55,9 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
     chatSettings,
     selectedTools,
     setSelectedTools,
-    assistantImages
+    assistantImages,
+    userTier,
+    userMessageCount
   } = useContext(ChatbotUIContext)
 
   const {
@@ -161,6 +164,8 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
       }
     }
   }
+
+  const userMessageLimit = MESSAGE_LIMITS[chatSettings.model][userTier]
 
   return (
     <>
@@ -279,6 +284,12 @@ export const ChatInput: FC<ChatInputProps> = ({}) => {
           )}
         </div>
       </div>
+
+      {userMessageCount >= userMessageLimit - 3 && userMessageCount < userMessageLimit && (
+        <div className="text-center text-yellow-500 mt-2">
+          {userMessageLimit - userMessageCount} Messages Left for today. Upgrade to get more usage.
+        </div>
+      )}
     </>
   )
 }

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -3,36 +3,48 @@ import { ChatbotUIContext } from "@/context/context"
 import { Tables } from "@/supabase/types"
 import { FC, useContext, useState } from "react"
 import { Message } from "../messages/message"
+import { MESSAGE_LIMITS } from "@/lib/tier-limits"
 
 interface ChatMessagesProps {}
 
 export const ChatMessages: FC<ChatMessagesProps> = ({}) => {
-  const { chatMessages, chatFileItems } = useContext(ChatbotUIContext)
+  const { chatMessages, chatFileItems, userTier, chatSettings, userMessageCount } = useContext(ChatbotUIContext)
 
   const { handleSendEdit } = useChatHandler()
 
   const [editingMessage, setEditingMessage] = useState<Tables<"messages">>()
 
-  return chatMessages
-    .sort((a, b) => a.message.sequence_number - b.message.sequence_number)
-    .map((chatMessage, index, array) => {
-      const messageFileItems = chatFileItems.filter(
-        (chatFileItem, _, self) =>
-          chatMessage.fileItems.includes(chatFileItem.id) &&
-          self.findIndex(item => item.id === chatFileItem.id) === _
-      )
+  const userMessageLimit = MESSAGE_LIMITS[chatSettings.model][userTier]
 
-      return (
-        <Message
-          key={chatMessage.message.sequence_number}
-          message={chatMessage.message}
-          fileItems={messageFileItems}
-          isEditing={editingMessage?.id === chatMessage.message.id}
-          isLast={index === array.length - 1}
-          onStartEdit={setEditingMessage}
-          onCancelEdit={() => setEditingMessage(undefined)}
-          onSubmitEdit={handleSendEdit}
-        />
-      )
-    })
+  return (
+    <>
+      {chatMessages
+        .sort((a, b) => a.message.sequence_number - b.message.sequence_number)
+        .map((chatMessage, index, array) => {
+          const messageFileItems = chatFileItems.filter(
+            (chatFileItem, _, self) =>
+              chatMessage.fileItems.includes(chatFileItem.id) &&
+              self.findIndex(item => item.id === chatFileItem.id) === _
+          )
+
+          return (
+            <Message
+              key={chatMessage.message.sequence_number}
+              message={chatMessage.message}
+              fileItems={messageFileItems}
+              isEditing={editingMessage?.id === chatMessage.message.id}
+              isLast={index === array.length - 1}
+              onStartEdit={setEditingMessage}
+              onCancelEdit={() => setEditingMessage(undefined)}
+              onSubmitEdit={handleSendEdit}
+            />
+          )
+        })}
+      {userMessageCount >= userMessageLimit && (
+        <div className="text-center text-red-500 mt-2">
+          Message limit reached for today. Upgrade to get more usage.
+        </div>
+      )}
+    </>
+  )
 }

--- a/context/context.tsx
+++ b/context/context.tsx
@@ -136,6 +136,12 @@ interface ChatbotUIContext {
   setSelectedTools: Dispatch<SetStateAction<Tables<"tools">[]>>
   toolInUse: string
   setToolInUse: Dispatch<SetStateAction<string>>
+
+  // NEW PROPERTIES FOR TIER AND MESSAGE COUNT
+  userTier: string
+  setUserTier: Dispatch<SetStateAction<string>>
+  userMessageCount: number
+  setUserMessageCount: Dispatch<SetStateAction<number>>
 }
 
 export const ChatbotUIContext = createContext<ChatbotUIContext>({
@@ -261,5 +267,11 @@ export const ChatbotUIContext = createContext<ChatbotUIContext>({
   selectedTools: [],
   setSelectedTools: () => {},
   toolInUse: "none",
-  setToolInUse: () => {}
+  setToolInUse: () => {},
+
+  // NEW PROPERTIES FOR TIER AND MESSAGE COUNT
+  userTier: "",
+  setUserTier: () => {},
+  userMessageCount: 0,
+  setUserMessageCount: () => {}
 })

--- a/docs/db-modifications.md
+++ b/docs/db-modifications.md
@@ -1,0 +1,25 @@
+# Database Modifications for Tier-Based Message Limits
+
+To implement tier-based message limits, you need to modify your database schema to track the number of messages sent per day for each model and user tier. Here are the steps to do this:
+
+1. **Add a new table to track message counts:**
+
+```sql
+CREATE TABLE user_message_counts (
+    id SERIAL PRIMARY KEY,
+    user_id UUID NOT NULL,
+    model_id VARCHAR(255) NOT NULL,
+    tier VARCHAR(50) NOT NULL,
+    message_count INTEGER DEFAULT 0,
+    date DATE NOT NULL,
+    CONSTRAINT unique_user_model_date UNIQUE (user_id, model_id, date)
+);
+```
+
+2. **Update your API routes to increment the message count:**
+
+In each of your API route files (e.g., `app/api/chat/anthropic/route.ts`, `app/api/chat/azure/route.ts`, etc.), add logic to increment the message count and check the limits before calling the third-party AI API.
+
+3. **Display warnings and errors:**
+
+Update your frontend code to display warnings when the message limit is close to being reached and errors when the limit is reached. This can be done by checking the remaining message count and updating the UI accordingly.

--- a/lib/tier-limits.ts
+++ b/lib/tier-limits.ts
@@ -1,0 +1,261 @@
+export const TIERS = {
+  FREE: "FREE",
+  BASIC: "BASIC",
+  PLUS: "PLUS",
+  MAX: "MAX"
+};
+
+export const MESSAGE_LIMITS = {
+  "claude-2.1": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "claude-instant-1.2": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "claude-3-haiku-20240307": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "claude-3-sonnet-20240229": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "claude-3-opus-20240229": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "claude-3-5-sonnet-20240620": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gemini-1.5-flash-latest": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gemini-pro": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gemini-1.5-pro-latest": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gemini-pro-vision": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "mistral-tiny": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "mistral-small": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "mistral-medium": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "mistral-large-2402": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "llama3-8b-8192": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "llama3-70b-8192": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "llama-3.1-8b-instant": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "llama-3.1-70b-versatile": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "llama-3.2-3b-preview": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "llama-3.2-11b-vision-preview": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "llama-3.2-90b-text-preview": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "mixtral-8x7b-32768": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gemma-7b-it": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gemma2-9b-it": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gpt-3.5-turbo": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gpt-4-turbo-preview": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gpt-4-1106-vision-preview": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gpt-4": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "gpt-4o": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "pplx-7b-online": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "pplx-70b-online": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "pplx-7b-chat": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "pplx-70b-chat": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "mixtral-8x7b-instruct": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "mistral-7b-instruct": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "llama-2-70b-chat": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "codellama-34b-instruct": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "codellama-70b-instruct": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "sonar-small-chat": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "sonar-small-online": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "sonar-medium-chat": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  },
+  "sonar-medium-online": {
+    [TIERS.FREE]: 10,
+    [TIERS.BASIC]: 50,
+    [TIERS.PLUS]: 100,
+    [TIERS.MAX]: 200
+  }
+};

--- a/public/worker-development.js
+++ b/public/worker-development.js
@@ -1,5 +1,0 @@
-/******/ (() => { // webpackBootstrap
-var __webpack_exports__ = {};
-self.__WB_DISABLE_DEV_LOGS = true;
-/******/ })()
-;

--- a/public/worker-wYNVqgN3LjSULkLaJJ0iE.js
+++ b/public/worker-wYNVqgN3LjSULkLaJJ0iE.js
@@ -1,0 +1,1 @@
+self.__WB_DISABLE_DEV_LOGS=!0;


### PR DESCRIPTION
Add new properties to `ChatbotUIContext` for user tier and message count.

* Add `userTier` and `userMessageCount` properties to `ChatbotUIContext` type definition.
* Initialize `userTier` and `userMessageCount` properties in `ChatbotUIContext` with default values.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PixelVerseIT/chatbot-ui?shareId=accc9619-bfe6-4b73-8cd2-5cebf00148a6).